### PR TITLE
Remove trailing comma so that it is valid JSON

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,5 +10,5 @@
     }
   ],
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "portrait"
 }


### PR DESCRIPTION
Loading the Heroku app gives me `Manifest parsing error: Line: 14, column: 2, Trailing comma not allowed.`
