### PR TITLE
Fixes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,5 +10,7 @@
     }
   ],
   "display": "standalone",
-  "orientation": "portrait"
+  "orientation": "portrait",
+  "gcm_sender_id": "",
+  "gcm_user_visible_only": true
 }

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var dirty = require('dirty');
 var db = dirty('subscriptions.db');
 
 var activeSubscriptionIds = [];
-var previousRequestTime = new Date();
+var previousRequestTime = 0;
 
 /**
  * Setup

--- a/server.js
+++ b/server.js
@@ -64,22 +64,8 @@ app.get('/notification-data.json', function (req, res) {
 /**
  * I don't know how to load heroku config values into a json file.
  */
-var manifest = {
-  "short_name": "Caturday Post",
-  "name": "Caturday Post",
-  "start_url": "./?utm_source=web_app_manifest",
-  "icons": [
-    {
-      "src": "/images/caticon.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    }
-  ],
-  "display": "standalone",
-  "orientation": "portrait",
-  "gcm_sender_id": process.env.GCM_SENDER,
-  "gcm_user_visible_only": true
-}
+var manifest = require('./manifest.json');
+manifest.gcm_sender_id = process.env.GCM_SENDER;
 
 app.get('/manifest.json', function (req, res) {
   res.json(manifest);


### PR DESCRIPTION
A couple of small bugs:
- The static content middleware has priority, so the manifest with the sender ID in wasn't getting served.
- Setting the previousRequestTime to the current time on startup prevents you from sending cats until the server has been up > 1 minute
